### PR TITLE
Added sort for Edit Categories NMS-10654

### DIFF
--- a/opennms-web-api/src/main/java/org/opennms/web/svclayer/support/DefaultAdminCategoryService.java
+++ b/opennms-web-api/src/main/java/org/opennms/web/svclayer/support/DefaultAdminCategoryService.java
@@ -492,6 +492,8 @@ public class DefaultAdminCategoryService implements
                 m_nodes.remove(node);
             }
             
+            Collections.sort(m_nodes);
+                
             m_sortedMemberNodes =
                 new ArrayList<OnmsNode>(memberNodes);
             Collections.sort(m_sortedMemberNodes);


### PR DESCRIPTION
Added sort to Available nodes list box in the Manage Surveillance Categories form.  In Edit, the lists of nodes (both member and available) are unsorted. They should be sorted by node label.  Change was made to sort list of Available nodes.

https://issues.opennms.org/browse/NMS-10654


Thanks for taking time to contribute!

Please read our [Contribution Guidelines](https://github.com/OpenNMS/opennms/blob/develop/CONTRIBUTING.md) and format the title of the pull request in the format of:

NMS-10654: Added sort for Edit Categories

Please use the [JIRA](https://issues.opennms.org) issue number and create a link in the JIRA issue back to this pull request so we have a quick reference from the issue to the pull request.

* JIRA: http://issues.opennms.org/browse/NMS-10654

Our [continuous integration system](http://bamboo.internal.opennms.com:8085) will test and verify your changes.
